### PR TITLE
NGX-726: Configure and enable query cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,18 @@ Available variables are listed below with their default values (you can also see
 
 | Variable | Description |
 | -------- | ----------- |
-| mysql_daemon | Default: `mariadb`
-| mysql_supports_innodb_large_prefix | Default: `true`
-| mysql_root_home | Default: `/root`
-| mysql_root_password_update | Default: `false`
-| mysql_root_username | Default: `root`
 | mysql_config_file | Default: `/etc/my.cnf`
 | mysql_config_include_dir | Default: `/etc/my.cnf.d`
-| mysql_pid_file | Default: `/var/run/mariadb/mariadb.pid`
-| mysql_socket | Default: `true`
-| mysql_socket_path | Default: `/var/lib/mysql/mysql.sock`
+| mysql_daemon | Default: `mariadb`
+| mysql_innodb_buffer_pool_size | Default: `128M`
+| mysql_innodb_file_per_table | Default: `1`
+| mysql_innodb_log_buffer_size | Default: `16M`
+| mysql_innodb_log_file_size | Default: `96M`
 | mysql_log_dir | Default: `/var/log/`
 | mysql_log_error | Default: `"{{ mysql_log_dir }}/mariadb/mariadb.log"`
 | mysql_log_file_group | Default: `mysql`
-| mysql_slow_query_log_enabled | Default: `true`
-| mysql_slow_query_log_file | Default: `"{{ mysql_log_dir }}/mysql-slow.log"`
-| mysql_syslog_tag | Default: `mariadb`
 | mysql_packages | Default: `The MySQL packages to install`
-| password_generate | Default: `"{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"`
+| mysql_pid_file | Default: `/var/run/mariadb/mariadb.pid`
 | mysql_query_alloc_block_size | Default: `16384`
 | mysql_query_cache_limit | Default: `1M`
 | mysql_query_cache_min_res_unit | Default: `4096`
@@ -47,10 +41,16 @@ Available variables are listed below with their default values (you can also see
 | mysql_query_cache_type | Default: `1`
 | mysql_query_cache_wlock_invalidate | Default: `0`
 | mysql_query_prealloc_size | Default: `24576`
-| mysql_innodb_file_per_table | Default: `1`
-| mysql_innodb_buffer_pool_size | Default: `128M`
-| mysql_innodb_log_buffer_size | Default: `16M`
-| mysql_innodb_log_file_size | Default: `96M`
+| mysql_root_home | Default: `/root`
+| mysql_root_password_update | Default: `false`
+| mysql_root_username | Default: `root`
+| mysql_slow_query_log_enabled | Default: `true`
+| mysql_slow_query_log_file | Default: `"{{ mysql_log_dir }}/mysql-slow.log"`
+| mysql_socket | Default: `true`
+| mysql_socket_path | Default: `/var/lib/mysql/mysql.sock`
+| mysql_supports_innodb_large_prefix | Default: `true`
+| mysql_syslog_tag | Default: `mariadb`
+| password_generate | Default: `"{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"`
 
 
 ## Example Playbook

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Available variables are listed below with their default values (you can also see
 | mysql_syslog_tag | Default: `mariadb`
 | mysql_packages | Default: `The MySQL packages to install`
 | password_generate | Default: `"{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"`
+| mysql_query_alloc_block_size | Default: `16384`
+| mysql_query_cache_limit | Default: `1M`
+| mysql_query_cache_min_res_unit | Default: `4096`
+| mysql_query_cache_size | Default: `16M`
+| mysql_query_cache_strip_comments | Default: `0`
+| mysql_query_cache_type | Default: `1`
+| mysql_query_cache_wlock_invalidate | Default: `0`
+| mysql_query_prealloc_size | Default: `24576`
+| mysql_innodb_file_per_table | Default: `1`
+| mysql_innodb_buffer_pool_size | Default: `128M`
+| mysql_innodb_log_buffer_size | Default: `16M`
+| mysql_innodb_log_file_size | Default: `96M`
+
 
 ## Example Playbook
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,19 @@ password_generate: "{{ lookup('password', '/dev/null length=15 chars=ascii_lette
 #
 # InnoDB Variables
 #
+mysql_innodb_buffer_pool_size: 128M
 mysql_innodb_file_per_table: 1
-mysql_innodb_buffer_pool_size: 128MB
-mysql_innodb_log_buffer_size: 16MB
+mysql_innodb_log_buffer_size: 16M
+mysql_innodb_log_file_size: 96M
+
+#
+# Query Cache Variables
+#
+mysql_query_alloc_block_size: 16384
+mysql_query_cache_limit: 1M
+mysql_query_cache_min_res_unit: 4096
+mysql_query_cache_size: 16M
+mysql_query_cache_strip_comments: 0
+mysql_query_cache_type: 1
+mysql_query_cache_wlock_invalidate: 0
+mysql_query_prealloc_size: 24576

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,3 +40,12 @@
     group: root
     mode: "0644"
   notify: restart mysql
+
+- name: Configure MySQL Query Cache
+  template:
+    src: etc/my.cnf.d/qcache.cnf.j2
+    dest: "{{ mysql_config_include_dir }}/qcache.cnf"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart mysql

--- a/templates/etc/my.cnf.d/innodb.cnf.j2
+++ b/templates/etc/my.cnf.d/innodb.cnf.j2
@@ -1,8 +1,9 @@
 # {{ ansible_managed }}
-# INNODB OPTIONS
+# InnoDB options
+
+
 [mysqld]
 innodb_file_per_table           = {{ mysql_innodb_file_per_table }}
 innodb_buffer_pool_size         = {{ mysql_innodb_buffer_pool_size }}
 innodb_log_buffer_size          = {{ mysql_innodb_log_buffer_size }}
-innodb_log_file_size            = {{ ( ( mysql_innodb_buffer_pool_size | human_to_bytes ) / 4 ) | int }}
-
+innodb_log_file_size            = {{ mysql_innodb_log_file_size }}

--- a/templates/etc/my.cnf.d/logs.cnf.j2
+++ b/templates/etc/my.cnf.d/logs.cnf.j2
@@ -1,4 +1,6 @@
 # {{ ansible_managed }}
 # Logging options
+
+
 [mysqld]
 log_error = {{ mysql_log_error }}

--- a/templates/etc/my.cnf.d/qcache.cnf.j2
+++ b/templates/etc/my.cnf.d/qcache.cnf.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+# Query Cache options
+
+
+[mysqld]
+query_alloc_block_size          = {{ mysql_query_alloc_block_size }}
+query_cache_limit               = {{ mysql_query_cache_limit }}
+query_cache_min_res_unit        = {{ mysql_query_cache_min_res_unit }}
+query_cache_size                = {{ mysql_query_cache_size }}
+query_cache_strip_comments      = {{ mysql_query_cache_strip_comments }}
+query_cache_type                = {{ mysql_query_cache_type }}
+query_cache_wlock_invalidate    = {{ mysql_query_cache_wlock_invalidate }}
+query_prealloc_size             = {{ mysql_query_prealloc_size }}


### PR DESCRIPTION
- "This is extremely useful in high-read, low-write environments (such as most websites). It does not scale well in environments with high throughput on multi-core machines, so it is disabled by default." (Source: https://mariadb.com/kb/en/query-cache/).  Query Cache has taken a less desirable place in most mysql setups because of the high adoption of multi-core and multi-server deployments where it can be a bottleneck; however, as states by MariaDB it is still useful for websites and fits well in our use case where the deployment consists of a single site on the server.