### PR TITLE
No pid file mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Available variables are listed below with their default values (you can also see
 | mysql_log_error | Default: `"{{ mysql_log_dir }}/mariadb/mariadb.log"`
 | mysql_log_file_group | Default: `mysql`
 | mysql_packages | Default: `The MySQL packages to install`
-| mysql_pid_file | Default: `/var/run/mariadb/mariadb.pid`
 | mysql_query_alloc_block_size | Default: `16384`
 | mysql_query_cache_limit | Default: `1M`
 | mysql_query_cache_min_res_unit | Default: `4096`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,6 @@ mysql_root_username: root
 mysql_config_file: /etc/my.cnf
 mysql_config_include_dir: /etc/my.cnf.d
 
-mysql_pid_file: /var/run/mariadb/mariadb.pid
-
 mysql_socket: true
 mysql_socket_path: /var/lib/mysql/mysql.sock
 

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -24,7 +24,6 @@
       - mysql_root_username
       - mysql_config_file
       - mysql_config_include_dir
-      - mysql_pid_file
       - mysql_socket_path
       - mysql_log_dir
       - mysql_log_error


### PR DESCRIPTION
- Each OS package manages the pid file slightly different.  It becomes a bit problematic to try and ensure that MySQL can create the pid file as defined in the playbook.  For this reason, it's best for us to rely on the package defaults.  If the end user really wants to manage the pid file, they can do so manually with their own care.