### PR TITLE
T3O2-13112: Resolve perl-DBD-MySQL package dependencies on Redhat 9+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,6 @@ mysql_syslog_tag: mariadb
 mysql_packages:
   - mariadb-server
   - MySQL-python
-  - perl-DBD-MySQL
 
 #
 # Meta

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -3,11 +3,17 @@
   ansible.builtin.include_vars: debian.yml
   when: ansible_os_family | lower == "debian"
 
-- name: (RedHat 8+) Include os_family vars
+- name: (RedHat 8) Include os_family vars
   ansible.builtin.include_vars: "redhat-8.yml"
   when:
     - ansible_os_family | lower == "redhat"
-    - ansible_distribution_major_version >= "8"
+    - ansible_distribution_major_version = "8"
+
+- name: (RedHat 9+) Include os_family vars
+  ansible.builtin.include_vars: "redhat-9.yml"
+  when:
+    - ansible_os_family | lower == "redhat"
+    - ansible_distribution_major_version >= "9"    
 
 - name: (Debian 11+, Ubuntu 20.04+) Drop python 2.x packages
   ansible.builtin.set_fact:

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,6 @@
+---
+mysql_packages:
+  - mariadb-server
+  - mariadb-server-utils
+  - perl-DBD-MariaDB
+  - python3-PyMySQL


### PR DESCRIPTION
`perl-DBD-MySQL-4.053-1.el9.x86_64` introduced a dependency on mariadb-common which conflicts with packages from the official upstream MariaDB repository.  To resolve we do the following: 
- Remove `perl-DBD-MySQL` from default package list in `defaults/main.yml`
- Copy `vars/redhat-8.yml` to `vars/redhat-9.yml` and swap `perl-DBD-MySQL` with `perl-DBD-MariaDB`
- Add logic to `tasks/packages/facts.yml` for Redhat 9+
This ensures we maintain support for CentOS 7 while resolving dependency issues on AlmaLinux 9.