### PR TITLE
T3O2-15660: MariaDB 10.11 (UltraStack ONE)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,27 +41,3 @@ jobs:
         env:
           MOLECULE_IMAGE: ${{ matrix.image }}
           MOLECULE_COMMAND: ${{ matrix.command }}
-
-  molecule-legacy:
-    name: Molecule Test Legacy OS
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: geerlingguy/docker-centos7-ansible:latest
-            command: /usr/lib/systemd/systemd
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - name: Install test dependencies
-        run: pip install -r requirements.txt
-
-      - name: Run Molecule Test
-        run: molecule test
-        env:
-          MOLECULE_IMAGE: ${{ matrix.image }}
-          MOLECULE_COMMAND: ${{ matrix.command }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mysql_version: "10.6"
+mysql_version: "10.11"
 mysql_version_flat: '{{ php_version | replace(".", "") }}'
 
 mysql_daemon: mariadb

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - "7"
         - "8"
         - "9"
     - name: Debian


### PR DESCRIPTION
Part of Epic T3O2-15312 (fleet MariaDB → 10.11). MariaDB 10.6 is EOL 2026-07-06; 10.11 is LTS to Feb 2028.

## Changes
- `defaults/main.yml`: default `mysql_version` `10.6` → `10.11` (feeds the MariaDB repo baseurl in both redhat.yml and debian.yml).
- `meta/main.yml`: drop EL 7 — MariaDB has no 10.11 builds for EL7.
- `.github/workflows/main.yml`: remove the `molecule-legacy` centos7 job, which would fail on 10.11.

## Validation
- `ansible-lint` (production profile): 0 failures / 0 warnings on 27 files.
- Molecule matrix (EL8/EL9, Debian 10/11, Ubuntu 20.04/22.04) runs on this PR.

Ref: https://imh-internal.atlassian.net/browse/T3O2-15660